### PR TITLE
Set Arrow Down Icon to Black

### DIFF
--- a/lib/slimy_card.dart
+++ b/lib/slimy_card.dart
@@ -257,7 +257,7 @@ class _SlimyCardState extends State<SlimyCard> with TickerProviderStateMixin {
                   width: 50,
                   child: RotationTransition(
                     turns: arrowAnimation,
-                    child: Icon(Icons.keyboard_arrow_down),
+                    child: Icon(Icons.keyboard_arrow_down,color: Colors.black),
                   ),
                   decoration: BoxDecoration(
                     color: Colors.white,


### PR DESCRIPTION
Given that the BoxDecoration for the opn button is explicitly set to Colors.white, this means the arrow cannot be seen when using
flutter's Material dark mode as the icon also appears white. Therefore explicitly setting the icon to black ensures it can always be seen regardless of theme settings.